### PR TITLE
Modified facebook-location-dialog to fall back to default-location-di…

### DIFF
--- a/Node/core/src/locale/en/botbuilder-location.json
+++ b/Node/core/src/locale/en/botbuilder-location.json
@@ -19,5 +19,5 @@
     "SingleResultFound": "I found this result. Is this the correct address?",    
     "StreetAddress": "street address",
     "TitleSuffix": " Type or say an address",
-    "TitleSuffixFacebook": " Tap 'Send Location' to choose an address."
+    "TitleSuffixFacebook": " Tap 'Send Location' to choose an address, or type or say an address."
 }   


### PR DESCRIPTION
In this Facebook chat windows the "Send Location" option is presented, but is not able to be used:
![image](https://cloud.githubusercontent.com/assets/7020816/21755335/3ae5e8b6-d677-11e6-848e-8bc0e20e1c2c.png)
This message is displayed to the user, and then they are stuck, because there is no other location entity option:
![image](https://cloud.githubusercontent.com/assets/7020816/21755337/44eb2880-d677-11e6-9e08-7e0eb115c991.png)
My pull request resolves this situation by allowing an option to specify a text-based input instead (the pull request prompts with more generic text than this screenshot):
![image](https://cloud.githubusercontent.com/assets/7020816/21755338/4c8715d6-d677-11e6-9a61-9cbf1833dd49.png)
BotBuilder-Location is a great component. Any questions about my request, please ask!