### PR TITLE
Hotfix/node required dialog response place broken

### DIFF
--- a/Node/CHANGELOG.md
+++ b/Node/CHANGELOG.md
@@ -1,0 +1,13 @@
+## 1.0.4
+Bug fixes:
+  - Fixed required dialog response: In case there are no required fields, the response now includes the place.
+
+## 1.0.1
+
+Features:
+  - Address look up and validation using Bing's Maps REST services. 
+  - User location returned as strongly-typed object complying with schema.org.
+  - Address disambiguation when more than one address is found.
+  - Support for declaring required location fields.
+  - Support for FB Messenger's location picker GUI dialog.
+  - Open-source code (C# and Node.js) with customizable dialog strings.

--- a/Node/core/lib/dialogs/required-fields-dialog.js
+++ b/Node/core/lib/dialogs/required-fields-dialog.js
@@ -32,7 +32,7 @@ function createDialog() {
             next();
         }
         else {
-            session.endDialogWithResult({ response: args.place });
+            session.endDialogWithResult({ response: { place: args.place } });
         }
     })
         .onDefault(function (session) {

--- a/Node/core/package.json
+++ b/Node/core/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-location",
   "author": "Microsoft Corp.",
   "description": "An open-source location picker control for Microsoft Bot Framework powered by Bing's Maps REST services. This control makes the process of collecting and validating the user's desired location in a conversation easy and reliable.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "keywords": [
     "botbuilder",

--- a/Node/core/src/dialogs/required-fields-dialog.ts
+++ b/Node/core/src/dialogs/required-fields-dialog.ts
@@ -32,7 +32,7 @@ function createDialog() {
                 session.dialogData.requiredFieldsFlag = args.requiredFields;
                 next();
             } else {
-                session.endDialogWithResult({ response: args.place });
+                session.endDialogWithResult({ response: { place: args.place } });
             }
         })
         .onDefault((session) => {


### PR DESCRIPTION
Fixed required dialog response: In case there are no required fields, the response now includes the place.
Plus
Node version minor bump up: 1.0.3 to 1.0.4