### PR TITLE
Node: confirm dialog invalid response bug fix

### DIFF
--- a/Node/core/lib/consts.js
+++ b/Node/core/lib/consts.js
@@ -26,6 +26,7 @@ exports.Strings = {
     "InvalidLocationResponse": "InvalidLocationResponse",
     "InvalidLocationResponseFacebook": "InvalidLocationResponseFacebook",
     "InvalidStartBranchResponse": "InvalidStartBranchResponse",
+    "InvalidYesNo": "InvalidYesNo",
     "LocationNotFound": "LocationNotFound",
     "Locality": "Locality",
     "MultipleResultsFound": "MultipleResultsFound",

--- a/Node/core/lib/dialogs/confirm-dialog.js
+++ b/Node/core/lib/dialogs/confirm-dialog.js
@@ -24,7 +24,7 @@ function createDialog() {
             session.endDialogWithResult(result);
             return;
         }
-        session.send(consts_1.Strings.InvalidLocationResponse).sendBatch();
+        session.send(consts_1.Strings.InvalidYesNo).sendBatch();
     });
 }
 function parseBoolean(input) {

--- a/Node/core/lib/locale/en/botbuilder-location.json
+++ b/Node/core/lib/locale/en/botbuilder-location.json
@@ -24,6 +24,7 @@
     "InvalidLocationResponse": "Didn't get that. Choose a location or cancel.",
     "InvalidLocationResponseFacebook": "Tap on Send Location to proceed; type or say cancel to exit.",
     "InvalidStartBranchResponse": "Tap one of the options to proceed; type or say cancel to exit.",
+    "InvalidYesNo": "I didn't understand. Please enter 'yes' or 'no'.",
     "LocationNotFound": "I could not find this address. Please try again.",
     "Locality": "city or locality",
     "MultipleResultsFound": "I found these results. Type or say a number to choose the address, or enter 'other' to select another address.",

--- a/Node/core/src/consts.ts
+++ b/Node/core/src/consts.ts
@@ -27,6 +27,7 @@ export const Strings = {
     "InvalidLocationResponse": "InvalidLocationResponse",
     "InvalidLocationResponseFacebook": "InvalidLocationResponseFacebook",
     "InvalidStartBranchResponse": "InvalidStartBranchResponse",
+    "InvalidYesNo": "InvalidYesNo",
     "LocationNotFound": "LocationNotFound",
     "Locality": "Locality",
     "MultipleResultsFound": "MultipleResultsFound",

--- a/Node/core/src/dialogs/confirm-dialog.ts
+++ b/Node/core/src/dialogs/confirm-dialog.ts
@@ -27,7 +27,7 @@ function createDialog() {
                 return;
             }
 
-            session.send(Strings.InvalidLocationResponse).sendBatch();
+            session.send(Strings.InvalidYesNo).sendBatch();
         });
 }
 

--- a/Node/core/src/locale/en/botbuilder-location.json
+++ b/Node/core/src/locale/en/botbuilder-location.json
@@ -24,6 +24,7 @@
     "InvalidLocationResponse": "Didn't get that. Choose a location or cancel.",
     "InvalidLocationResponseFacebook": "Tap on Send Location to proceed; type or say cancel to exit.",
     "InvalidStartBranchResponse": "Tap one of the options to proceed; type or say cancel to exit.",
+    "InvalidYesNo": "I didn't understand. Please enter 'yes' or 'no'.",
     "LocationNotFound": "I could not find this address. Please try again.",
     "Locality": "city or locality",
     "MultipleResultsFound": "I found these results. Type or say a number to choose the address, or enter 'other' to select another address.",


### PR DESCRIPTION
Fixing the string sent to the user in the confirm dialog in case of an invalid response