### PR TITLE
Handling no previously stored favorites

### DIFF
--- a/Node/core/lib/botbuilder-location.js
+++ b/Node/core/lib/botbuilder-location.js
@@ -4,6 +4,7 @@ var botbuilder_1 = require("botbuilder");
 var common = require("./common");
 var consts_1 = require("./consts");
 var place_1 = require("./place");
+var favorites_manager_1 = require("./services/favorites-manager");
 var addFavoriteLocationDialog = require("./dialogs/add-favorite-location-dialog");
 var confirmDialog = require("./dialogs/confirm-dialog");
 var retrieveLocationDialog = require("./dialogs/retrieve-location-dialog");
@@ -38,7 +39,7 @@ function getLocationPickerPrompt() {
     return [
         function (session, args, next) {
             session.dialogData.args = args;
-            if (!args.skipFavorites) {
+            if (!args.skipFavorites && (new favorites_manager_1.FavoritesManager(session.userData)).getFavorites().length > 0) {
                 session.beginDialog('start-hero-card-dialog');
             }
             else {

--- a/Node/core/src/botbuilder-location.ts
+++ b/Node/core/src/botbuilder-location.ts
@@ -3,6 +3,7 @@ import { AttachmentLayout, IDialogResult, IPromptOptions, CardAction, HeroCard, 
 import * as common from './common';
 import { Strings, LibraryName } from './consts';
 import { Place } from './place';
+import { FavoritesManager } from './services/favorites-manager';
 import * as addFavoriteLocationDialog from './dialogs/add-favorite-location-dialog';
 import * as confirmDialog from './dialogs/confirm-dialog';
 import * as retrieveLocationDialog from './dialogs/retrieve-location-dialog'
@@ -64,7 +65,8 @@ function getLocationPickerPrompt() {
         // handle different ways of retrieving a location (favorite, other, etc)
         (session: Session, args: ILocationPromptOptions, next: (results?: IDialogResult<any>) => void) => {
             session.dialogData.args = args;
-            if (!args.skipFavorites) {
+
+            if (!args.skipFavorites && (new  FavoritesManager(session.userData)).getFavorites().length > 0) {
                 session.beginDialog('start-hero-card-dialog');
             }
             else {


### PR DESCRIPTION
added a check so that if the user has no favorite locations stored, the favorites vs other choices are not shown in the start.